### PR TITLE
add: Dockerfile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 *.dll
 *.so
 *.dylib
+errwrapped
 
 # Test binary, build with `go test -c`
 *.test

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM golang:1.12 as builder
+
+WORKDIR /go/src/github.com/hmarui66/errwrapped
+COPY . .
+RUN go get -u golang.org/x/tools/go/analysis
+RUN CGO_ENABLED=0 go build -i -o /errwrapped -ldflags "-s -w" ./cmd/errwrapped
+
+FROM golang:1.12-alpine
+
+RUN apk add build-base
+COPY --from=builder /errwrapped /
+
+ENTRYPOINT ["/errwrapped"]


### PR DESCRIPTION
# やったこと

- Dockerfileの追加
    - goがないと動かなかったので、`golang:1.12-alpine`を使っています。
    - alpineの場合、`build-base`ないと動かなかったです。